### PR TITLE
Add parameter gen-package-path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 output_tests.diff
+go.mod
+go.sum
+.vscode

--- a/generators/deepequal.go
+++ b/generators/deepequal.go
@@ -24,7 +24,8 @@ import (
 // CustomArgs is used tby the go2idl framework to pass args specific to this
 // generator.
 type CustomArgs struct {
-	BoundingDirs []string // Only deal with types rooted under these dirs.
+	BoundingDirs   []string // Only deal with types rooted under these dirs.
+	GenPackagePath string   // Overwritten package path to be generated
 }
 
 // This is the comment tag that carries parameters for deep-copy generation.
@@ -185,6 +186,14 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		}
 	}
 
+	// Obtain override package path value
+	genPackagePath := ""
+	if customArgs, ok := arguments.CustomArgs.(*CustomArgs); ok {
+		if len(customArgs.GenPackagePath) > 0 {
+			genPackagePath = customArgs.GenPackagePath
+		}
+	}
+
 	for i := range inputs {
 		klog.V(5).Infof("Considering pkg %q", i)
 		pkg := context.Universe[i]
@@ -241,6 +250,10 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 				if strings.Contains(expandedPath, "/vendor/") {
 					path = expandedPath
 				}
+			}
+			// Set override package path if it is set.
+			if len(genPackagePath) > 0 {
+				path = genPackagePath
 			}
 			packages = append(packages,
 				&generator.DefaultPackage{

--- a/main.go
+++ b/main.go
@@ -28,6 +28,8 @@ func main() {
 	customArgs := &generators.CustomArgs{}
 	pflag.CommandLine.StringSliceVar(&customArgs.BoundingDirs, "bounding-dirs", customArgs.BoundingDirs,
 		"Comma-separated list of import paths which bound the types for which deep-copies will be generated.")
+	pflag.CommandLine.StringVar(&customArgs.GenPackagePath, "gen-package-path", customArgs.GenPackagePath,
+		"Override generated package path which deep-copies will be generated.")
 	arguments.CustomArgs = customArgs
 
 	// Run it.


### PR DESCRIPTION
PoC: Add new parameter --gen-package-path

Current implementation take package information by context path.
But it returns including package url path if it runs under
${GOPATH}/src/[your package with domain]
As a result, generated code will be placed in the directory
with domain name folders.

This fix add the new parameter to overwrite package path to
generate deepequal code.

This package path will be the path under output-file-base.

For example:
deepequal-gen -O /tmp --gen-package-path ./test/gen
will place generated deepequal code in directory /tmp/test/gen

Signed-off-by: Takamasa Takenaka <takamasa.takenaka@windriver.com>